### PR TITLE
Issue#162の修正

### DIFF
--- a/src/main/java/com/github/ucchyocean/lc/PlayerListener.java
+++ b/src/main/java/com/github/ucchyocean/lc/PlayerListener.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -269,7 +270,7 @@ public class PlayerListener implements Listener {
             // LunaChatPreChatEvent イベントコール
             LunaChatPreChatEvent preChatEvent = new LunaChatPreChatEvent(
                     global.getName(), player, event.getMessage());
-            Utility.callEventSync(preChatEvent);
+            Bukkit.getPluginManager().callEvent(preChatEvent);
             if ( preChatEvent.isCancelled() ) {
                 event.setCancelled(true);
                 return;
@@ -556,7 +557,7 @@ public class PlayerListener implements Listener {
         // LunaChatPreChatEvent イベントコール
         LunaChatPreChatEvent preChatEvent = new LunaChatPreChatEvent(
                 channel.getName(), player, message);
-        Utility.callEventSync(preChatEvent);
+        Bukkit.getPluginManager().callEvent(preChatEvent);
         if ( preChatEvent.isCancelled() ) {
             return true;
         }

--- a/src/main/java/com/github/ucchyocean/lc/Utility.java
+++ b/src/main/java/com/github/ucchyocean/lc/Utility.java
@@ -24,7 +24,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 
 /**
  * ユーティリティクラス
@@ -347,22 +346,5 @@ public class Utility {
     @SuppressWarnings("deprecation")
     public static Player getPlayerExact(String name) {
         return Bukkit.getPlayer(stripColor(name));
-    }
-
-    /**
-     * イベントを同期処理で呼び出します
-     *
-     * @param event 対象のイベント
-     * @return タスクのID (登録に失敗した場合は-1)
-     * @since 2.8.10
-     */
-    public static int callEventSync(final Event event) {
-        return Bukkit.getScheduler().scheduleSyncDelayedTask(LunaChat.getInstance(), new Runnable() {
-
-            @Override
-            public void run() {
-                Bukkit.getPluginManager().callEvent(event);
-            }
-        });
     }
 }

--- a/src/main/java/com/github/ucchyocean/lc/channel/Channel.java
+++ b/src/main/java/com/github/ucchyocean/lc/channel/Channel.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -238,7 +239,7 @@ public abstract class Channel implements ConfigurationSerializable {
         // イベントコール
         LunaChatChannelMemberChangedEvent event =
                 new LunaChatChannelMemberChangedEvent(this.name, this.members, after);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return;
         }
@@ -272,7 +273,7 @@ public abstract class Channel implements ConfigurationSerializable {
         // イベントコール
         LunaChatChannelMemberChangedEvent event =
                 new LunaChatChannelMemberChangedEvent(this.name, this.members, after);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return;
         }

--- a/src/main/java/com/github/ucchyocean/lc/channel/ChannelImpl.java
+++ b/src/main/java/com/github/ucchyocean/lc/channel/ChannelImpl.java
@@ -148,7 +148,7 @@ public class ChannelImpl extends Channel {
         LunaChatChannelChatEvent event =
                 new LunaChatChannelChatEvent(getName(), player,
                         preReplaceMessage, maskedMessage, msgFormat);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return;
         }
@@ -414,7 +414,7 @@ public class ChannelImpl extends Channel {
         LunaChatChannelMessageEvent event =
                 new LunaChatChannelMessageEvent(
                         getName(), player, message, recipients, name, originalMessage);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         message = event.getMessage();
         recipients = event.getRecipients();
 

--- a/src/main/java/com/github/ucchyocean/lc/channel/ChannelManager.java
+++ b/src/main/java/com/github/ucchyocean/lc/channel/ChannelManager.java
@@ -12,13 +12,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import com.github.ucchyocean.lc.LunaChat;
 import com.github.ucchyocean.lc.LunaChatAPI;
 import com.github.ucchyocean.lc.Resources;
-import com.github.ucchyocean.lc.Utility;
 import com.github.ucchyocean.lc.event.LunaChatChannelCreateEvent;
 import com.github.ucchyocean.lc.event.LunaChatChannelRemoveEvent;
 import com.github.ucchyocean.lc.japanize.JapanizeType;
@@ -441,7 +441,7 @@ public class ChannelManager implements LunaChatAPI {
         // イベントコール
         LunaChatChannelCreateEvent event =
                 new LunaChatChannelCreateEvent(channelName, sender);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return null;
         }
@@ -478,7 +478,7 @@ public class ChannelManager implements LunaChatAPI {
         // イベントコール
         LunaChatChannelRemoveEvent event =
                 new LunaChatChannelRemoveEvent(channelName, sender);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return false;
         }

--- a/src/main/java/com/github/ucchyocean/lc/channel/DelayedJapanizeConvertTask.java
+++ b/src/main/java/com/github/ucchyocean/lc/channel/DelayedJapanizeConvertTask.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -124,7 +125,7 @@ public class DelayedJapanizeConvertTask extends BukkitRunnable {
         String channelName = (channel == null) ? "" : channel.getName();
         LunaChatPostJapanizeEvent event =
                 new LunaChatPostJapanizeEvent(channelName, player, org, japanized);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return false;
         }

--- a/src/main/java/com/github/ucchyocean/lc/command/OptionCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc/command/OptionCommand.java
@@ -8,6 +8,7 @@ package com.github.ucchyocean.lc.command;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -140,7 +141,7 @@ public class OptionCommand extends SubCommandAbst {
         // イベントコール
         LunaChatChannelOptionChangedEvent event =
                 new LunaChatChannelOptionChangedEvent(cname, sender, options);
-        Utility.callEventSync(event);
+        Bukkit.getPluginManager().callEvent(event);
         if ( event.isCancelled() ) {
             return true;
         }

--- a/src/main/java/com/github/ucchyocean/lc/event/LunaChatBaseEvent.java
+++ b/src/main/java/com/github/ucchyocean/lc/event/LunaChatBaseEvent.java
@@ -5,6 +5,7 @@
  */
 package com.github.ucchyocean.lc.event;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -25,6 +26,7 @@ public abstract class LunaChatBaseEvent extends Event {
      * @param channelName チャンネル名
      */
     public LunaChatBaseEvent(String channelName) {
+        super(!Bukkit.isPrimaryThread());
         this.channelName = channelName;
     }
 


### PR DESCRIPTION
イベントのインスタンス生成の根幹の部分で同期スレッドかどうかのチェックを入れました（LunaChatBaseEventのコンストラクタの`super(!Bukkit.isPrimaryThread())`の部分）
これにより、イベントをnewした場所が同期スレッドなら同期イベント、非同期スレッドなら非同期イベントが生成されるようになっています
PluginManager#callEventをどのタイミングで使ってもその場でnewさえしていれば同期/非同期によるエラーが発生しません

Issue#162の原因だったUtility#callEventSyncは消しておきました

マージする場合、バージョンは変えていないのでそちらでお願いします