### PR TITLE
[Add] Bungeecord support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,5 +203,19 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.9</version>
     </dependency>
+    <dependency>
+      <groupId>net.md-5</groupId>
+      <artifactId>bungeecord-api</artifactId>
+      <version>1.15-SNAPSHOT</version>
+      <type>jar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.md-5</groupId>
+      <artifactId>bungeecord-api</artifactId>
+      <version>1.15-SNAPSHOT</version>
+      <type>javadoc</type>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/github/ucchyocean/lc/BungeeListener.java
+++ b/src/main/java/com/github/ucchyocean/lc/BungeeListener.java
@@ -1,0 +1,90 @@
+package com.github.ucchyocean.lc;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.github.ucchyocean.lc.channel.Channel;
+import com.github.ucchyocean.lc.channel.ChannelBungeePlayer;
+import com.github.ucchyocean.lc.channel.ChannelPlayer;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+public class BungeeListener implements PluginMessageListener {
+
+    List<String> onlinePlayers = new ArrayList<>();
+
+    BungeeListener() {}
+
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+        if (!channel.equals("lc:tobukkit")) {
+            return;
+        }
+
+        try {
+            ByteArrayInputStream byteArrayIn = new ByteArrayInputStream(message);
+            DataInputStream in = new DataInputStream(byteArrayIn);
+
+            String operation = in.readUTF();
+            if (operation.equalsIgnoreCase("chat")) {
+                String channelName = in.readUTF();
+                String playerName = in.readUTF();
+                String playerDisplayName = in.readUTF();
+                String playerPrefix = in.readUTF();
+                String playerSuffix = in.readUTF();
+                String worldName = in.readUTF();
+                String chatMessage = in.readUTF();
+                boolean japanize = in.readBoolean();
+                boolean canUseColorCode = in.readBoolean();
+
+                in.close();
+                byteArrayIn.close();
+
+                boolean defaultJapanize = LunaChat.getInstance().getLunaChatAPI().isPlayerJapanize(playerName);
+                if (japanize != defaultJapanize) {
+                    LunaChat.getInstance().getLunaChatAPI().setPlayersJapanize(playerName, japanize);
+                }
+
+                ChannelPlayer channelPlayer = new ChannelBungeePlayer(playerName, playerPrefix, playerSuffix,
+                        worldName, playerDisplayName, canUseColorCode);
+
+                // プライベートメッセージ
+                if (channelName.contains(">")) {
+                    String invited = channelName.substring(channelName.indexOf(">") + 1);
+                    LunaChat.getInstance().getLunaChatAPI()
+                            .sendTellMessage(channelPlayer, invited, chatMessage);
+                    return;
+                }
+
+                Channel lcChannel = LunaChat.getInstance().getLunaChatAPI().getChannel(channelName);
+                if (lcChannel != null && lcChannel.isBungee() && !lcChannel.isWorldRange() && lcChannel.getChatRange() == 0) {
+                    lcChannel.chat(channelPlayer, chatMessage);
+                }
+
+                if (japanize != defaultJapanize) {
+                    LunaChat.getInstance().getLunaChatAPI().setPlayersJapanize(playerName, defaultJapanize);
+                }
+
+            } else if (operation.equalsIgnoreCase("updateplayers")) {
+                onlinePlayers = new ArrayList<>(Arrays.asList(in.readUTF().split(",", -1)));
+            } else if (operation.equalsIgnoreCase("joinplayer")) {
+                String playerName = in.readUTF();
+                if (!onlinePlayers.contains(playerName)) {
+                    onlinePlayers.add(playerName);
+                }
+            } else if (operation.equalsIgnoreCase("disconnectplayer")) {
+                onlinePlayers.remove(in.readUTF());
+            }
+
+            in.close();
+            byteArrayIn.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/ucchyocean/lc/LunaChatAPI.java
+++ b/src/main/java/com/github/ucchyocean/lc/LunaChatAPI.java
@@ -192,4 +192,12 @@ public interface LunaChatAPI {
      * LunaChatの全データを再読み込みする
      */
     public void reloadAllData();
+
+    /**
+     * Tellコマンドの実行処理を行う
+     * @param inviter
+     * @param invitedName
+     * @param message
+     */
+    public void sendTellMessage(ChannelPlayer inviter, String invitedName, String message);
 }

--- a/src/main/java/com/github/ucchyocean/lc/bungeecord/BungeeMain.java
+++ b/src/main/java/com/github/ucchyocean/lc/bungeecord/BungeeMain.java
@@ -1,0 +1,69 @@
+package com.github.ucchyocean.lc.bungeecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+
+public class BungeeMain extends Plugin {
+
+    private static BungeeMain instance;
+    private PluginMessageListener pluginMessageListener;
+
+    @Override
+    public void onEnable() {
+        instance = this;
+        pluginMessageListener = new PluginMessageListener();
+        getProxy().getScheduler().schedule(instance, this::updatePlayers, 5, 60, TimeUnit.SECONDS);
+        getProxy().registerChannel("lc:tobukkit");
+        getProxy().registerChannel("lc:tobungee");
+        pluginMessageListener.start();
+        PlayerListener.start();
+    }
+
+    @Override
+    public void onDisable() {
+        getProxy().getScheduler().cancel(instance);
+        getProxy().unregisterChannel("lc:tobukkit");
+        getProxy().unregisterChannel("lc:tobungee");
+        pluginMessageListener.stop();
+        PlayerListener.stop();
+    }
+
+    public static BungeeMain getInstance() {
+        if (instance == null) {
+            instance = (BungeeMain) ProxyServer.getInstance().getPluginManager().getPlugin("LunaChat");
+            if (instance == null) {
+                throw new ExceptionInInitializerError("Cannot initialize LunaChat.");
+            }
+        }
+    
+        return instance;
+    }
+
+    private void updatePlayers() {
+        try {
+            ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+            DataOutputStream out = new DataOutputStream(byteOutStream);
+
+            out.writeUTF("updateplayers");
+            out.writeUTF(ProxyServer.getInstance().getPlayers().stream()
+                    .map(ProxiedPlayer::getName).reduce("", (p1, p2) -> p1 + "," + p2));
+
+            byte[] data = byteOutStream.toByteArray();
+            for (ServerInfo server : ProxyServer.getInstance().getServers().values()) {
+                server.sendData("lc:tobukkit", data);
+            }
+
+            out.close();
+            byteOutStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/ucchyocean/lc/bungeecord/PlayerListener.java
+++ b/src/main/java/com/github/ucchyocean/lc/bungeecord/PlayerListener.java
@@ -1,0 +1,65 @@
+package com.github.ucchyocean.lc.bungeecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.event.PlayerDisconnectEvent;
+import net.md_5.bungee.api.event.PostLoginEvent;
+import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+
+public class PlayerListener implements Listener {
+
+    private static final BungeeMain PLUGIN = BungeeMain.getInstance();
+    private static final PlayerListener INSTANCE = new PlayerListener();
+
+    private PlayerListener() {
+    }
+
+    static void start() {
+        ProxyServer.getInstance().getPluginManager().registerListener(PLUGIN, INSTANCE);
+    }
+
+    static void stop() {
+        ProxyServer.getInstance().getPluginManager().unregisterListener(INSTANCE);
+    }
+
+    @EventHandler
+    public void onJoin(PostLoginEvent event) {
+        onConnectionChange(event, event.getPlayer().getName());
+    }
+
+    @EventHandler
+    public void onQuit(PlayerDisconnectEvent event) {
+        onConnectionChange(event, event.getPlayer().getName());
+    }
+
+    private void onConnectionChange(Event event, String player) {
+        String operation;
+        if (event instanceof PostLoginEvent) {
+            operation = "joinplayer";
+        } else if (event instanceof PlayerDisconnectEvent) {
+            operation = "disconnectplayer";
+        } else {
+            return;
+        }
+
+        try {
+            ByteArrayOutputStream byteArrayOut = new ByteArrayOutputStream();
+            DataOutputStream out = new DataOutputStream(byteArrayOut);
+            out.writeUTF(operation);
+            out.writeUTF(player);
+            for (ServerInfo server : ProxyServer.getInstance().getServers().values()) {
+                server.sendData("lc:tobukkit", byteArrayOut.toByteArray());
+            }
+            out.close();
+            byteArrayOut.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/ucchyocean/lc/bungeecord/PluginMessageListener.java
+++ b/src/main/java/com/github/ucchyocean/lc/bungeecord/PluginMessageListener.java
@@ -1,0 +1,104 @@
+package com.github.ucchyocean.lc.bungeecord;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class PluginMessageListener implements Listener {
+
+    private final BungeeMain plugin = BungeeMain.getInstance();
+
+    void start() {
+        ProxyServer.getInstance().getPluginManager().registerListener(plugin, this);
+    }
+
+    void stop() {
+        ProxyServer.getInstance().getPluginManager().unregisterListener(this);
+    }
+
+    PluginMessageListener() {}
+
+    @EventHandler
+    public void onPluginMessageReceived(PluginMessageEvent event) {
+        if (!event.getTag().equals("lc:tobungee")) {
+            return;
+        }
+
+        try {
+            ByteArrayInputStream byteInStream = new ByteArrayInputStream(event.getData());
+            DataInputStream in = new DataInputStream(byteInStream);
+            ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+            DataOutputStream out = new DataOutputStream(byteOutStream);
+
+            // 操作。chat、updateplayerなど
+            String operation = in.readUTF();
+            out.writeUTF(operation);
+
+            if (operation.equalsIgnoreCase("chat")) {
+                // チャンネル名
+                String channelName = in.readUTF();
+                out.writeUTF(channelName);
+
+                // プレイヤー名
+                String playerName = in.readUTF();
+                out.writeUTF(playerName);
+
+                // プレイヤー表示名
+                String playerDisplayName = in.readUTF();
+                out.writeUTF(playerDisplayName);
+
+                // プレイヤープレフィックス
+                String playerPrefix = in.readUTF();
+                out.writeUTF(playerPrefix);
+
+                // プレイヤーサフィックス
+                String playerSuffix = in.readUTF();
+                out.writeUTF(playerSuffix);
+
+                // プレイヤーのいるワールド
+                String worldName = in.readUTF();
+                out.writeUTF(worldName);
+
+                // チャットメッセージ
+                String chatMessage = in.readUTF();
+                out.writeUTF(chatMessage);
+
+                boolean japanize = in.readBoolean();
+                out.writeBoolean(japanize);
+
+                boolean canUseColorCode = in.readBoolean();
+                out.writeBoolean(canUseColorCode);
+
+                in.close();
+                byteInStream.close();
+                out.close();
+                byteOutStream.close();
+
+                // 発言者のみが発言のプラグインメッセージを送信する。
+                if (!((ProxiedPlayer) event.getReceiver()).getName().equals(playerName)) {
+                    return;
+                }
+
+                byte[] data = byteOutStream.toByteArray();
+                String serverFrom = ProxyServer.getInstance().getPlayer(playerName).getServer().getInfo().getName();
+
+                for (ServerInfo server : ProxyServer.getInstance().getServers().values()) {
+                    if (!server.getName().equals(serverFrom)) {
+                        server.sendData("lc:tobukkit", data, false);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/ucchyocean/lc/channel/Channel.java
+++ b/src/main/java/com/github/ucchyocean/lc/channel/Channel.java
@@ -55,6 +55,7 @@ public abstract class Channel implements ConfigurationSerializable {
     private static final String KEY_MUTE_EXPIRES = "mute_expires";
     private static final String KEY_ALLOWCC = "allowcc";
     private static final String KEY_JAPANIZE = "japanize";
+    private static final String KEY_BUNGEE = "bungee";
 
     /** 参加者 */
     private List<ChannelPlayer> members;
@@ -123,6 +124,9 @@ public abstract class Channel implements ConfigurationSerializable {
 
     /** チャンネルごとのjapanize変換設定 */
     private JapanizeType japanizeType;
+
+    /** Bungeecordチャンネルかどうか */
+    private boolean bungee;
 
     /**
      * コンストラクタ
@@ -455,6 +459,7 @@ public abstract class Channel implements ConfigurationSerializable {
         map.put(KEY_MUTE_EXPIRES, getStringLongMap(muteExpires));
         map.put(KEY_ALLOWCC, allowcc);
         map.put(KEY_JAPANIZE, japanizeType == null ? null : japanizeType.toString());
+        map.put(KEY_BUNGEE, bungee);
         return map;
     }
 
@@ -490,6 +495,7 @@ public abstract class Channel implements ConfigurationSerializable {
         channel.muteExpires = castToChannelPlayerLongMap(data.get(KEY_MUTE_EXPIRES));
         channel.allowcc = castWithDefault(data.get(KEY_ALLOWCC), true);
         channel.japanizeType = JapanizeType.fromID(data.get(KEY_JAPANIZE) + "", null);
+        channel.bungee = castWithDefault(data.get(KEY_BUNGEE), false);
         return channel;
     }
 
@@ -886,6 +892,22 @@ public abstract class Channel implements ConfigurationSerializable {
      */
     public void setJapanizeType(JapanizeType japanize) {
         this.japanizeType = japanize;
+    }
+
+    /**
+     * Bungeecord内のサーバーのうち、同じ名前かつbungee=trueのチャンネル同士で貫通チャットが出来るかどうか。
+     * @return bungeeを返す。
+     */
+    public boolean isBungee() {
+        return bungee;
+    }
+
+    /**
+     * Bungeecord内のサーバーのうち、同じ名前かつbungee=trueのチャンネル同士で貫通チャットが出来るかどうかを設定する。
+     * @param bungee サーバー貫通チャンネルにするかどうか
+     */
+    public void setBungee(boolean bungee) {
+        this.bungee = bungee;
     }
 
     /**

--- a/src/main/java/com/github/ucchyocean/lc/channel/ChannelBungeePlayer.java
+++ b/src/main/java/com/github/ucchyocean/lc/channel/ChannelBungeePlayer.java
@@ -1,0 +1,78 @@
+package com.github.ucchyocean.lc.channel;
+
+import com.github.ucchyocean.lc.channel.ChannelPlayerName;
+
+/**
+ * 他のサーバーに居るプレイヤーの情報を格納しておくためのChannelPlayerクラス。
+ */
+public class ChannelBungeePlayer extends ChannelPlayerName {
+
+    private final String prefix;
+    private final String suffix;
+    private final String worldName;
+    private final String displayName;
+    private boolean canUseColorCode;
+
+    public ChannelBungeePlayer(String name, String prefix, String suffix, String worldName, String displayName, boolean canUseColorCode) {
+        super(name);
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.worldName = worldName;
+        this.displayName = displayName;
+        this.canUseColorCode = canUseColorCode;
+    }
+
+    /**
+     * 他のサーバーにおけるプレフィックスを適応するためのメソッド。
+     */
+    @Override
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * 他のサーバーにおけるサフィックスを適応するためのメソッド。
+     */
+    @Override
+    public String getSuffix() {
+        return suffix;
+    }
+
+    /**
+     * 他のサーバーにおけるディスプレイネームを適応するためのメソッド。
+     */
+    @Override
+    public String getDisplayName() {
+        if (isOnline()) {
+            return getPlayer().getDisplayName();
+        } else {
+            return displayName;
+        }
+    }
+
+    /**
+     * 他のサーバーの、発言者がいるワールド名を取得するメソッド。
+     * 発言当時のワールド名を保存するものであり、このインスタンスを格納していて、発言者がワールド移動した場合
+     * は情報に不整合が生じる。
+     */
+    @Override
+    public String getWorldName() {
+        if (isOnline()) {
+            return super.getWorldName();
+        } else {
+            return worldName;
+        }
+    }
+
+    /**
+     * カラーコードが使えるかどうかを他のサーバーでも適応するための実装。
+     */
+    @Override
+    public boolean hasPermission(String node) {
+        if (node.equals("lunachat.allowcc")) {
+            return canUseColorCode;
+        }
+
+        return super.hasPermission(node);
+    }
+}

--- a/src/main/java/com/github/ucchyocean/lc/command/DataMaps.java
+++ b/src/main/java/com/github/ucchyocean/lc/command/DataMaps.java
@@ -14,13 +14,13 @@ import java.util.HashMap;
 public class DataMaps {
 
     /** 招待された人→招待されたチャンネル名 のマップ */
-    protected static HashMap<String, String> inviteMap;
+    public final static HashMap<String, String> inviteMap;
 
     /** 招待された人→招待した人 のマップ */
-    protected static HashMap<String, String> inviterMap;
+    public final static HashMap<String, String> inviterMap;
 
     /** tell/rコマンドの送信者→受信者 のマップ */
-    protected static HashMap<String, String> privateMessageMap;
+    public final static HashMap<String, String> privateMessageMap;
 
     static {
         inviteMap = new HashMap<String, String>();

--- a/src/main/java/com/github/ucchyocean/lc/command/LunaChatMessageCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc/command/LunaChatMessageCommand.java
@@ -10,9 +10,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
 import com.github.ucchyocean.lc.LunaChat;
-import com.github.ucchyocean.lc.LunaChatAPI;
 import com.github.ucchyocean.lc.Resources;
-import com.github.ucchyocean.lc.channel.Channel;
 import com.github.ucchyocean.lc.channel.ChannelPlayer;
 
 /**
@@ -56,58 +54,9 @@ public class LunaChatMessageCommand implements CommandExecutor {
         }
 
         // メッセージを送信する
-        sendTellMessage(inviter, invitedName, message.toString().trim());
+        LunaChat.getInstance().getLunaChatAPI()
+                .sendTellMessage(inviter, invitedName, message.toString().trim());
         return true;
-    }
-
-    /**
-     * Tellコマンドの実行処理を行う
-     * @param inviter
-     * @param invitedName
-     * @param message
-     */
-    protected void sendTellMessage(ChannelPlayer inviter, String invitedName, String message) {
-
-        // 招待相手が存在するかどうかを確認する
-        ChannelPlayer invited = ChannelPlayer.getChannelPlayer(invitedName);
-        if ( invited == null || !invited.isOnline() ) {
-            sendResourceMessage(inviter, PREERR,
-                    "errmsgNotfoundPlayer", invitedName);
-            return;
-        }
-
-        // 招待相手が自分自身でないか確認する
-        if (inviter.getName().equals(invited.getName())) {
-            sendResourceMessage(inviter, PREERR,
-                    "errmsgCannotSendPMSelf");
-            return;
-        }
-
-        // チャンネルが存在するかどうかをチェックする
-        LunaChatAPI api = LunaChat.getInstance().getLunaChatAPI();
-        String cname = inviter.getName() + ">" + invited.getName();
-        Channel channel = api.getChannel(cname);
-        if ( channel == null ) {
-            // チャンネルを作成して、送信者、受信者をメンバーにする
-            channel = api.createChannel(cname);
-            channel.setVisible(false);
-            channel.addMember(inviter);
-            channel.addMember(invited);
-            channel.setPrivateMessageTo(invited.getName());
-        }
-
-        // メッセージがあるなら送信する
-        if ( message.trim().length() > 0 ) {
-            channel.chat(inviter, message);
-        }
-
-        // 送信履歴を残す
-        DataMaps.privateMessageMap.put(
-                invited.getName(), inviter.getName());
-        DataMaps.privateMessageMap.put(
-                inviter.getName(), invited.getName());
-
-        return;
     }
 
     /**
@@ -135,23 +84,5 @@ public class LunaChatMessageCommand implements CommandExecutor {
         }
         String msg = String.format(pre + org, args);
         sender.sendMessage(msg);
-    }
-
-    /**
-     * メッセージリソースのメッセージを、カラーコード置き換えしつつ、senderに送信する
-     * @param sender メッセージの送り先
-     * @param pre プレフィックス
-     * @param key リソースキー
-     * @param args リソース内の置き換え対象キーワード
-     */
-    protected void sendResourceMessage(ChannelPlayer cp, String pre,
-            String key, Object... args) {
-
-        String org = Resources.get(key);
-        if ( org == null || org.equals("") ) {
-            return;
-        }
-        String msg = String.format(pre + org, args);
-        cp.sendMessage(msg);
     }
 }

--- a/src/main/java/com/github/ucchyocean/lc/command/LunaChatReplyCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc/command/LunaChatReplyCommand.java
@@ -8,6 +8,7 @@ package com.github.ucchyocean.lc.command;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
+import com.github.ucchyocean.lc.LunaChat;
 import com.github.ucchyocean.lc.Resources;
 import com.github.ucchyocean.lc.channel.ChannelPlayer;
 
@@ -57,7 +58,8 @@ public class LunaChatReplyCommand extends LunaChatMessageCommand {
             message.append(args[i] + " ");
         }
 
-        sendTellMessage(inviter, invitedName, message.toString().trim());
+        LunaChat.getInstance().getLunaChatAPI()
+                .sendTellMessage(inviter, invitedName, message.toString().trim());
 
         return true;
     }

--- a/src/main/java/com/github/ucchyocean/lc/command/OptionCommand.java
+++ b/src/main/java/com/github/ucchyocean/lc/command/OptionCommand.java
@@ -356,6 +356,30 @@ public class OptionCommand extends SubCommandAbst {
             }
         }
 
+        if ( options.containsKey("bungee") ) {
+            // Bungeecord内の他のサーバーの同名チャンネル間でチャットを貫通するかどうか。
+
+            String pnode = PERMISSION_NODE + ".bungee";
+            if ( !sender.hasPermission(pnode) ) {
+                sendResourceMessage(sender, PREERR,
+                        "errmsgNotPermission", pnode);
+            } else {
+
+                String temp = options.get("bungee");
+                if ( temp.equalsIgnoreCase("false") ) {
+                    channel.setBungee(false);
+                    sendResourceMessage(sender, PREINFO,
+                            "cmdmsgOption", "bungee", "false");
+                    setOption = true;
+                } else if ( temp.equalsIgnoreCase("true") ) {
+                    channel.setBungee(true);
+                    sendResourceMessage(sender, PREINFO,
+                            "cmdmsgOption", "bungee", "true");
+                    setOption = true;
+                }
+            }
+        }
+
         if ( !channel.isGlobalChannel() ) {
 
             if ( options.containsKey("password") ) {

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,0 +1,5 @@
+name: ${project.name}
+main: com.github.ucchyocean.lc.bungeecord.BungeeMain
+version: ${project.version}
+authors: [ucchy, YukiLeafX, LazyGon]
+description: ${project.description}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -198,6 +198,9 @@ permissions:
   lunachat.option.japanize:
     description: japanizeオプション設定コマンドの使用権限
     default: true
+  lunachat.option.bungee:
+    description: bungeeオプション設定コマンドの使用権限
+    default: op
   lunachat.option.*:
     children:
       lunachat.option.description: true
@@ -209,6 +212,7 @@ permissions:
       lunachat.option.visible: true
       lunachat.option.allowcc: true
       lunachat.option.japanize: true
+      lunachat.option.bungee: true
     description: オプション設定の全コマンドの使用権限
 
   lunachat-admin.mod-all-channels:


### PR DESCRIPTION
- tell/replyのBungeecord対応
- option "bungee=true"、範囲無制限チャンネルは、別の鯖の同名で"bungee=true"、範囲無制限チャンネルに発言が貫通
- 細かい仕様は[このPL](https://github.com/okocraft/LunaChatBridge)と同じ

※範囲無制限=ワールドレンジではないかつチャットレンジ無制限

ちょっとロジックが粗いかもしれません。PluginMessageChannel周りが特に。
あと、上記リンク先のLunaChatBridgeを本体に組み込むからこそ付け足したい機能がいくつか（例えば、同名チャンネル間のメンバーやOptionの同期など）ありますが、そこまでは書いてません。

とりあえずLunaChatBridgeを使ったときと同じように動作してくれることは確認済みです。
試すときは
- このソースをビルドしてBungeecord鯖と2つ以上のBukkit鯖の両方に導入
- 適当な同名チャンネルを2つのBukkit鯖で作って、optionのbungeeをtrueにする
- 2人以上で両方の鯖にログインして適当に発言する

という手順になります。tellならチャンネル作らなくても試せます。

このPRによって、BungeeJapanizeMessengerがお役御免になります。