### PR TITLE
Bungeecord版のSuffix取得処理修正

### DIFF
--- a/src/main/java/com/github/ucchyocean/lc3/member/ChannelMemberProxiedPlayer.java
+++ b/src/main/java/com/github/ucchyocean/lc3/member/ChannelMemberProxiedPlayer.java
@@ -129,11 +129,11 @@ public class ChannelMemberProxiedPlayer extends ChannelMemberBungee {
 
         LuckPermsBridge luckperms = LunaChatBungee.getInstance().getLuckPerms();
         if ( luckperms != null ) {
-            return luckperms.getPlayerPrefix(id);
+            return luckperms.getPlayerSuffix(id);
         }
         BungeePermsBridge bungeeperms = LunaChatBungee.getInstance().getBungeePerms();
         if ( bungeeperms != null ) {
-            return bungeeperms.userPrefix(id.toString(), null, null);
+            return bungeeperms.userSuffix(id.toString(), null, null);
         }
         return "";
     }


### PR DESCRIPTION
Bungeecord+Luckperms環境でテストをしていた際にPrefixを設定するとSuffixの部分にも表示されたため修正しました
![javaw_DHFg0cT9We](https://user-images.githubusercontent.com/12862158/87556991-56de0e80-c6f2-11ea-8c22-de54ee2b7d44.png)