### PR TITLE
Send formatted messages to the console log

### DIFF
--- a/src/main/java/com/github/ucchyocean/lc3/channel/BukkitChannel.java
+++ b/src/main/java/com/github/ucchyocean/lc3/channel/BukkitChannel.java
@@ -179,6 +179,7 @@ public class BukkitChannel extends Channel {
             for ( ChannelMember p : recipients ) {
                 p.sendMessage(comps);
             }
+            message = format.toLegacyText();
         } else {
             for ( ChannelMember p : recipients ) {
                 p.sendMessage(message);

--- a/src/main/java/com/github/ucchyocean/lc3/channel/BungeeChannel.java
+++ b/src/main/java/com/github/ucchyocean/lc3/channel/BungeeChannel.java
@@ -114,6 +114,7 @@ public class BungeeChannel extends Channel {
             for ( ChannelMember p : recipients ) {
                 p.sendMessage(comps);
             }
+            message = format.toLegacyText();
         } else {
             for ( ChannelMember p : recipients ) {
                 p.sendMessage(message);


### PR DESCRIPTION
以前のバージョンだとコンソールログに出てくるログはフォーマットが適応されていましたが、最新のバージョンだとフォーマットが適応されずに出てきます
2.8.8
![powershell_QuaWNsaacQ](https://user-images.githubusercontent.com/12862158/88568162-7cb0cf00-d073-11ea-8eb5-ae984fb4fc74.png)
3.0.7
![powershell_1A2Qc5i95k](https://user-images.githubusercontent.com/12862158/88568358-d4e7d100-d073-11ea-9c53-a2ec09a8403f.png)
おそらくメッセージをクリックできるようにする改修を行った際にmessageにフォーマットが適応されていないため適応するように修正してみました
修正後
![powershell_N2tYANGdXX](https://user-images.githubusercontent.com/12862158/88569771-e4681980-d075-11ea-9b79-933a9a6551ac.png)
お手数をおかけしますがご確認をお願いいたします