### PR TITLE
[Fix] 16進カラーをTextComponentに適応できないバグを修正

### DIFF
--- a/src/main/java/com/github/ucchyocean/lc3/util/ClickableFormat.java
+++ b/src/main/java/com/github/ucchyocean/lc3/util/ClickableFormat.java
@@ -203,7 +203,7 @@ public class ClickableFormat {
             String text = matcher.group(2);
             String hover = matcher.group(3);
             String command = matcher.group(4);
-            TextComponent tc = new TextComponent(text);
+            TextComponent tc = new TextComponent(TextComponent.fromLegacyText(text));
             if ( !hover.isEmpty() ) {
                 tc.setHoverEvent(new HoverEvent(
                         HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(hover).create()));


### PR DESCRIPTION
`new TextComponent(String str)` は引数を解析せずそのまま格納するだけなので、プレイヤーに送信するときも `§` のまま送信されます。
つまり、例えば `#123456` はLunaChat側で `§x§1§2§3§4§5§6` に変換されますが、これはクライアント側で `§6` と解釈されます。
それに対して `TextComponent.fromLegacyText(String str)` は、ちゃんと文字列に含まれる `§` を解析して適当な色を `setColor` してくれます。これは、クライアント側でしっかりjsonメッセージとして解釈され、適切な色になります。
なので、こちらに置き換えました。

ちなみに、 `§x§1§1§1§1§1§1`  のような表現がクライアント側でうまく変換されないのは、この表現がvanillaのものではなくspigot由来のためだそうで。
vanillaではjsonメッセージ以外では16進カラーに対応していないらしいです。